### PR TITLE
Add sponsors.ini from admin repo

### DIFF
--- a/sponsors.ini
+++ b/sponsors.ini
@@ -1,0 +1,182 @@
+[sponsor-qnx]
+name = QNX
+url = http://www.qnx.com/
+logo = qnx-logos.png
+
+[sponsor-iweb]
+name = iWeb
+url = http://iweb.com/
+logo = iweb.png
+
+[sponsor-ludia]
+name = Ludia
+url = http://www.jobs.ludia.com/
+logo = ludia-black.png
+
+[sponsor-benelux]
+name = Brasserie Benelux
+url = http://www.brasseriebenelux.com/
+logo = BENELUX_black.png
+
+[sponsor-sfl]
+name = Savoir-faire Linux
+url = http://www.savoirfairelinux.com/?utm_source=montrealpython&utm_medium=banner&utm_campaign=banner
+logo = Savoir_faire_Linux3.png
+
+[sponsor-uqam]
+name = UQÀM
+url = http://uqam.ca
+logo = uqam-2.png
+
+[sponsor-ecometrica]
+name = Ecometrica
+url = http://ecometrica.ca
+logo = ecometrica-logo.png
+
+[sponsor-outbox]
+name = Outbox
+url = http://www.outboxtechnology.com/
+logo = Outbox_coul.png
+
+[sponsor-lesite]
+name = Le Site
+url = http://lesite.ca/
+logo = lesite.png
+
+[partner-studioxx]
+name = Studio XX
+url = http://www.studioxx.org/
+logo = studioXX.png
+
+[sponsor-caravan]
+name = Caravan
+url = http://caravan.coop/
+logo = CaravanLogo.png
+
+[sponsor-addison]
+name = Addison-Wesley
+url = http://www.informit.com/topics/topic.aspx?st=61456
+logo = addison_wesley_logo.jpg
+
+[sponsor-shwowp]
+name = Shwowp
+url = http://shwowp.com
+logo = shwowp_bagneutral.png
+
+[sponsor-apress]
+name = Apress
+url = http://apress.com
+logo = apress.png
+
+[sponsor-radialpoint]
+name = Radialpoint
+url = http://radialpoint.com
+logo = radialpoint.png
+
+[sponsor-notman]
+name = Notman House
+url = http://notman.org/en/
+logo = notman.png
+
+[sponsor-matchfwd]
+name = matchFWD
+url = http://matchfwd.com/
+logo = matchfwd_550px_wide.png
+
+[sponsor-concordia]
+name = Concordia
+url = http://www.ecaconcordia.ca/
+logo = bee.jpg
+
+[sponsor-shopify]
+name = Shopify
+url = http://www.shopify.ca/
+logo = Btn-shopify-n-bag.jpg
+
+[partner-qcouvert]
+name = qcouvert
+url = http://quebecouvert.org/citoyens
+logo = quebecouvert-logo-120dpi.png
+
+[partner-pyladies]
+name = pyladies
+url = http://www.meetup.com/PyLadiesMTL
+logo = pyladies.jpeg
+
+[mp-15]
+gold = uqam, benelux
+silver = sfl
+bronze = ecometrica
+
+[mp-16]
+gold = uqam, benelux
+silver = sfl, lesite
+bronze = ecometrica, addison
+
+[mp-17]
+gold = benelux, uqam
+silver = shwowp, sfl, lesite
+bronze = ecometrica, apress
+
+[mp-18]
+gold = benelux, uqam
+silver = lesite, sfl
+bronze = ecometrica, apress
+
+[mp-20]
+gold = ludia, benelux, uqam
+silver = lesite, sfl, iweb
+bronze = apress
+
+[mp-21]
+gold = qnx, ludia, benelux, uqam
+silver = lesite, sfl, iweb
+bronze = apress
+
+[mp-23]
+gold = qnx, ludia, radialpoint, benelux, uqam
+silver = lesite, sfl, iweb
+
+[mp-24]
+gold = qnx, ludia, benelux, uqam
+silver = lesite, sfl, iweb
+
+[mp-28]
+gold = ludia, benelux, notman
+silver = uqam, sfl, radialpoint, lesite, iweb
+
+[mp-29]
+gold = benelux
+silver = uqam, sfl, radialpoint, matchfwd, iweb, ludia
+
+[mp-30]
+gold = benelux
+silver = uqam, sfl, iweb
+
+[mp-31]
+gold = benelux, ludia, concordia
+silver = sfl, iweb, outbox
+
+[mp-32]
+gold = benelux, outbox, ludia, sfl, studioxx
+silver = caravan, iweb
+
+[mp-33]
+gold = benelux, outbox, ludia, sfl, caravan
+silver = iweb, uqam
+partner = qcouvert, studioxx
+
+[mp-34]
+gold = benelux, outbox, ludia, sfl, caravan
+silver = iweb, uqam
+partner = qcouvert, studioxx
+
+[mp-37]
+gold = benelux, outbox, ludia, sfl, shopify, caravan
+silver = iweb, uqam
+partner = qcouvert, studioxx, pyladies
+
+[mp-40]
+gold = benelux, outbox, ludia, sfl, caravan
+silver = iweb, uqam
+partner = qcouvert, studioxx, pyladies


### PR DESCRIPTION
This file is needed by the manage command `import_sponsors` 

https://github.com/mtlpy/mtlpyweb/blob/master/mtlpy/management/commands/import_sponsors.py#L16

* We could also just refactor that. 
* Do we use the event information in this file?

@mlhamel @nilovna @hadrien @peristeri 