### PR TITLE
Fix crash on flatpages with redirect_to mixing *args and **kwargs

### DIFF
--- a/mtlpy/templates/flatpages/default.html
+++ b/mtlpy/templates/flatpages/default.html
@@ -6,7 +6,7 @@
 {% for lang in LANGUAGES %}
 {% if lang.0 != LANGUAGE_CODE and flatpage.translation %}
 <li class="hidden-desktop">
-  <a href="{% url 'change_locale' lang.0 redirect_to=flatpage.translation.get_absolute_url %}">{{ lang.1 }}</a>
+  <a href="{% url 'change_locale' lang.0 %}">{{ lang.1 }}</a>
 </li>
 {% endif %}
 {% if lang.0 == LANGUAGE_CODE %}
@@ -27,7 +27,7 @@
 
   {% if lang.0 != LANGUAGE_CODE and flatpage.translation %}
   <li>
-    <a tabindex="-1" href="{% url 'change_locale' lang.0 redirect_to=flatpage.translation.get_absolute_url %}">{{ lang.1 }}</a>
+    <a tabindex="-1" href="{% url 'change_locale' lang.0 %}">{{ lang.1 }}</a>
   </li>
   {% endif %}
   {% if lang.0 == LANGUAGE_CODE %}


### PR DESCRIPTION
- Should at least fix the crash during the rendering
- **May** break something related to changing the language?

The doc: https://docs.djangoproject.com/en/2.0/ref/templates/builtins/#std:templatetag-url