### PR TITLE
Store sessions in cache (rather than in DB)

### DIFF
--- a/mtlpy/settings.py
+++ b/mtlpy/settings.py
@@ -35,6 +35,9 @@ DATABASES = {
     'default': env.db(),
 }
 
+# Store sessions in cache (redis) rather than in DB
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = env('ALLOWED_HOSTS', cast=list, default=[


### PR DESCRIPTION
The `django_sessions` table was huge (relative to our DB resource).
I truncated it.

There is probably a proper way to trim this table, but getting rid of those SQL requests would also help with request throttling we are experiencing from time to time.

With this PR, I propose switching to the cache as session store.

The doc: https://docs.djangoproject.com/en/2.1/topics/http/sessions/#using-cached-sessions

> Set SESSION_ENGINE to "django.contrib.sessions.backends.cache" for a simple caching session store. Session data will be stored directly in your cache. However, session data may not be persistent: cached data can be evicted if the cache fills up or if the cache server is restarted.

I think we can live with that.