### PR TITLE
Remove unused urls module

### DIFF
--- a/mtlpy/blog/urls.py
+++ b/mtlpy/blog/urls.py
@@ -1,9 +1,0 @@
-from django.conf.urls import patterns, url
-
-urlpatterns = patterns(
-    'mtlpy.blog.views',
-    url(r'^$', 'home'),
-    url(r'^(?P<year>\d{4})/$', 'archive'),
-    url(r'^(?P<year>\d{4})/(?P<month>\d{1,2})/$', 'archive'),
-    url(r'^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/$', 'archive'),
-)


### PR DESCRIPTION
When working on improvements on the pagination of blog posts, I found that there was an unused `urls` module in the `mtlpy.blog` app. This PR simply removes it. 😉