### PR TITLE
Updated the org contact mailing list addr

### DIFF
--- a/mtlpy/templates/inc/footer.html
+++ b/mtlpy/templates/inc/footer.html
@@ -60,7 +60,7 @@
 
         <div class="span5">
             <h4>{% trans "Contact the organizers" %}</h4>
-            <a class="" href="mailto:team@montrealpython.org">team@montrealpython.org</a>
+            <a class="" href="mailto:mtlpyteam@googlegroups.com">mtlpyteam@googlegroups.com</a>
         </div>
     </div>
 


### PR DESCRIPTION
L'addr qu'on distribue partout est mtlpyteam@googlegroups.com, l'autre n'est pas à jour et il n'y a pas de façon facile de garder les deux synchronisées. 